### PR TITLE
Full typecodes strings

### DIFF
--- a/ModuleMaps/modulelocator_test.txt
+++ b/ModuleMaps/modulelocator_test.txt
@@ -1,6 +1,7 @@
 plane u v typecode econdidx captureblock captureblockidx slinkidx fedid zside
-1 5 1 MH-F1W 0 0 0 0 0 -1
-1 5 2 ML-F2W 1 0 0 0 0 -1
-2 5 2 ML-F2W 0 0 0 0 1 -1
-2 5 3 ML-F2W 1 0 0 0 1 -1
-2 5 4 ML-F2W 2 0 0 0 1 -1
+1 5 1 ML-F3PT-TX-0003 0 0 0 0 49 -1
+1 5 2 ML-F3PC-MX-0003 1 0 0 0 49 -1
+1 5 2 ML-F3PC-MX-0004 2 0 0 0 49 -1
+1 5 3 ML_F2WX-IH-0011 3 0 0 0 49 -1
+1 5 4 ML-F3PT-TX-0001 4 0 0 0 49 -1
+1 5 5 ML-F3PT-TX-0002 5 0 0 0 49 -1

--- a/ModuleMaps/modulelocator_test.txt
+++ b/ModuleMaps/modulelocator_test.txt
@@ -2,6 +2,6 @@ plane u v typecode econdidx captureblock captureblockidx slinkidx fedid zside
 1 5 1 ML-F3PT-TX-0003 0 0 0 0 49 -1
 1 5 2 ML-F3PC-MX-0003 1 0 0 0 49 -1
 1 5 2 ML-F3PC-MX-0004 2 0 0 0 49 -1
-1 5 3 ML_F2WX-IH-0011 3 0 0 0 49 -1
+1 5 3 ML-F2WX-IH-0011 3 0 0 0 49 -1
 1 5 4 ML-F3PT-TX-0001 4 0 0 0 49 -1
 1 5 5 ML-F3PT-TX-0002 5 0 0 0 49 -1

--- a/ModuleMaps/modulelocator_test_2mods.txt
+++ b/ModuleMaps/modulelocator_test_2mods.txt
@@ -1,0 +1,3 @@
+plane u v typecode econdidx captureblock captureblockidx slinkidx fedid zside
+1 5 1 ML-F3PT-TX-0003 0 0 0 0 49 -1
+1 5 2 ML-F3PC-MX-0003 1 0 0 0 49 -1


### PR DESCRIPTION
Following `MM-TTTT-LL-NNNN` format according to
https://edms.cern.ch/ui/#!master/navigator/document?D:101059405:101148061:subDocs
and taking order (DQM v0, v1, v2, ...) from
https://docs.google.com/spreadsheets/d/1Kvej2OUE_1LFkd1kY0L-r7VuaUmhdMC2Z7Yi58bIeGM/edit#gid=0

To be parsed in [`HGCalMappingIndexESSource.cc`](https://github.com/CMS-HGCAL/cmssw/blob/dev/hackathon_base_CMSSW_14_1_0_pre0/Geometry/HGCalMapping/plugins/HGCalMappingIndexESSource.cc), and stored in map in [`HGCalMappingModuleIndexer.h`](https://github.com/CMS-HGCAL/cmssw/blob/dev/hackathon_base_CMSSW_14_1_0_pre0/CondFormats/HGCalObjects/interface/HGCalMappingModuleIndexer.h).